### PR TITLE
Fix 403 error when using moc compiler version > 0.6.2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,11 @@ pub fn download_compiler(version: &str) -> Result<PathBuf> {
         ),
     };
 
-    let response = reqwest::blocking::get(&target)?;
+    let client = reqwest::blocking::Client::new();
+    let response = client
+        .get(&target)
+        .header(reqwest::header::USER_AGENT, "vessel")
+        .send()?;
 
     if !response.status().is_success() {
         return Err(anyhow::anyhow!(


### PR DESCRIPTION
## Fix
**TLDR: To fix 403 forbidden compiler release downloads for versions > `0.6.2` that hit GitHub releases, update the `download_compiler` reqwest.get to set a User-Agent header**


## Motivation
I was running into issues where locally, I'm able to build my code and use moc version `0.6.20`, but my GitHub CI process runs into this forbidden error when trying to download the binary (note that I started with this template, and just update the compiler version [https://github.com/kritzcreek/motoko-library-template](https://github.com/kritzcreek/motoko-library-template)).

I don't run into this same error when using moc `0.6.2` and below, and I had tried every other version above it, but I run into the same forbidden error with `0.6.11` and `0.6.19`. 

I dug into this further and saw that every version up to `0.6.2` was released on `https://download.dfinity.systems/motoko/{version}/{os_arch}/motoko-{version}.tar.gz`,
but since then, from `0.6.3` up to `0.6.21` has been released on GitHub via the `https://github.com/dfinity/motoko/releases/download/{version}/motoko-{os}-{version}.tar.gz`.

Since I'm able to both locally (via vessel) and manually download (through the releases page) release binaries `0.6.3`+ from the GitHub releases page, this means there's either a specific download permission setting setting that's blocking the GitHub CI role or the request vessel is making to download the specific moc compiler version was messing up.

The code where the vessel package manager is attempting to download the binary can be found [here](https://github.com/dfinity/vessel/blob/main/src/lib.rs#L226).

For reference, this is the error I was receiving in the CI logs:
```
Run make check-strict
Error: Failed to download Motoko binaries for version 0.6.20, with "403 Forbidden"

Details: <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>HWH6Y08H658Y6KBG</RequestId><HostId>NNRcEQKUFwjZOQNNQQnVhmj6prO/0/IZBou0bUiyeZOs7+sIMqbRlHNRCU/X7XlfNfJM1cFKkcA=</HostId></Error>
find src -type f -name '*.mo' -print0 | xargs -0 /moc --package base .vessel/base/e0c95f909e17c431921f1be35800242a6ddd4a55/src -Werror --check
xargs: /moc: No such file or directory
make: *** [Makefile:9: check-strict] Error 127
```

Where the `check-strict` command is
```
check-strict:
	find src -type f -name '*.mo' -print0 | xargs -0 $(shell vessel bin)/moc $(shell vessel sources) -Werror --check
```

And the ci yaml file looked like this
[https://github.com/kritzcreek/motoko-library-template/blob/main/.github/workflows/ci.yml](https://github.com/kritzcreek/motoko-library-template/blob/main/.github/workflows/ci.yml)

Since I was receiving the "Failed to download" error mentioned on [this line], I started there and found an issue where if the `User-Agent` header is not specified, the GitHub API will throw this error. You can see on [this line](https://github.com/dfinity/vessel/blob/main/src/lib.rs#L392) that this header is set - and the API does not complain.


## The Fix (and proof it works)
* I've made the fix on [my fork](https://github.com/ByronBecker/vessel) with the release [here](https://github.com/ByronBecker/vessel/releases)
* A new package of mine using the moc compiler version `0.6.20` called `motoko-color` can be found [here](https://github.com/ByronBecker/motoko-color). This package is based off of the [motoko-library-template package](https://github.com/kritzcreek/motoko-library-template) written by @kritzcreek  As you can see from the check mark next to the most recent commit, each of the CI are passing (which involve downloading the motoko compiler from GitHub as the version = `0.6.20`, which is > 0.6.2, and both the [ci.yml](https://github.com/ByronBecker/motoko-color/blob/main/.github/workflows/ci.yml#L19) and [release.yml] are hitting my this commit of my vessel fork.