### PR TITLE
Bump download link `0.6.1` -> `0.6.4` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A simple package manager for the Motoko programming language.
 ## Getting started
 
 1. Download a copy of the `vessel` binary [from the release page](https://github.com/dfinity/vessel/releases) or build one yourself
-   1. For Ubuntu in `$HOME/bin` RUN `wget https://github.com/dfinity/vessel/releases/download/v0.6.1/vessel-linux64` 
+   1. For Ubuntu in `$HOME/bin` RUN `wget https://github.com/dfinity/vessel/releases/download/v0.6.4/vessel-linux64` 
 
-      For OSX in `usr/local/bin` RUN: `wget https://github.com/dfinity/vessel/releases/download/v0.6.1/vessel-macos` 
+      For macOS in `/usr/local/bin` RUN: `wget https://github.com/dfinity/vessel/releases/download/v0.6.4/vessel-macos` 
    2. Rename vessel-linux64 to vessel eg: RUN `mv vessel-linux64 vessel`
    3. Change permissions, `chmod +x vessel`
 2. Run `vessel init` in your project root.


### PR DESCRIPTION
This supersedes and closes #54, as `CLA` is still missing there.