### PR TITLE
Add optional `devDependencies` field in `vessel.dhall`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@ impl Vessel {
     fn read_manifest_file(&mut self) -> Result<()> {
         let manifest_file = PathBuf::from("vessel.dhall");
         self.manifest = serde_dhall::from_file(manifest_file)
-            .static_type_annotation()
             .parse()
             .context("Failed to parse the vessel.dhall file")?;
         Ok(())
@@ -98,11 +97,18 @@ impl Vessel {
 
     /// Installs all transitive dependencies and returns a mapping of package name -> installation location
     pub fn install_packages(&self, force: bool) -> Result<Vec<(Name, PathBuf)>> {
-        let install_plan = self
-            .package_set
-            .transitive_deps(self.manifest.dependencies.clone());
-
-        info!("Installing {} packages", install_plan.len());
+        let install_plan = self.package_set.transitive_deps(
+            [
+                self.manifest.dependencies.clone(),
+                self.manifest.dev_dependencies.clone(),
+            ]
+            .concat(),
+        );
+        info!(
+            "Installing {} package{}",
+            install_plan.len(),
+            if install_plan.len() == 1 { "" } else { "s" },
+        );
 
         let paths = install_plan
             .iter()
@@ -577,10 +583,26 @@ impl Package {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PackageSet(pub HashMap<Name, Package>);
 
-#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, serde_dhall::StaticType)]
-pub struct Manifest {
+#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize)] // , Serialize, Deserialize, serde_dhall::StaticType
+#[serde(rename_all = "camelCase")]
+pub struct LegacyManifest {
+    #[serde(default)]
     pub compiler: Option<String>,
+    #[serde(default)]
     pub dependencies: Vec<Name>,
+    #[serde(default, rename = "devDependencies")]
+    pub dev_dependencies: Vec<Name>,
+}
+
+#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Manifest {
+    #[serde(default)]
+    pub compiler: Option<String>,
+    #[serde(default)]
+    pub dependencies: Vec<Name>,
+    #[serde(default, rename = "devDependencies")]
+    pub dev_dependencies: Vec<Name>,
 }
 
 impl PackageSet {


### PR DESCRIPTION
This PR introduces the ability to specify local "dev dependencies" (well-known from [Cargo](https://doc.rust-lang.org/rust-by-example/testing/dev_dependencies.html) and [npm](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file)) for a Vessel package. 

Here's a concise explanation of dev dependencies from [Rust by Example](https://github.com/dfinity/vessel/compare/main...rvanasa:vessel:ryan/dev-dependencies?expand=1):
> Sometimes there is a need to have dependencies for tests (or examples, or benchmarks) only. 
> These dependencies are not propagated to other packages which depend on this package.

As a follow-up to https://github.com/dfinity/vscode-motoko/issues/66, this feature will provide a simpler and cleaner alternative to the `./vessel.dhall` + `test/vessel.dhall` pattern used in various official and community repositories (e.g. [motoko-base](https://github.com/dfinity/motoko-base/tree/master/test)). The goal is to improve readability for both humans and development tools (especially in the context of IDE integrations). 

This PR also makes it possible to omit fields in a `vessel.dhall` manifest. For instance, it's no longer necessary to write verbose default values such as `compiler = None Text`, which I expect will be appreciated by the community.  :)