### PR TITLE
Improve error message for GitHub API corner case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # vessel
 
-A simple package manager for the Motoko programming language.
+A package manager for the Motoko programming language.
+
+## Upcoming changes
+
+#### Vessel is currently being redesigned to improve the UX and scalability of the Motoko package ecosystem.
+If you want to see a specific feature in the next version of Vessel, we strongly encourage you to [submit a request](https://github.com/dfinity/vessel/issues/new) or [jump into the conversation](https://github.com/dfinity/vessel/issues). Thank you! 
 
 ## Getting started
 
@@ -75,8 +80,7 @@ The `"version"` field in the package set format refers to any git ref so you can
 put a branch name, a commit hash or a tag in there.
 
 **CAREFUL:** `vessel` has no way of invalidating "moving" references like a
-branch name. If you push a new commit to the branch you'll need to manually
-reset your caches and re-install.
+branch name. If you push a new commit to the branch you'll need to run `vessel install --force` to bypass your local cache.
 
 ### How do I add a local package to my package set?
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,7 +431,7 @@ pub fn fetch_latest_package_set() -> Result<(Url, Hash)> {
         ));
     }
     let releases: Vec<GhRelease> = response.json()?;
-    let release = &releases.get(0).ok_or_else(|| anyhow::anyhow!("Unable to find any vessel-package-set releases from {}.\nPlease try again in a few minutes or open an issue at https://github.com/dfinity/vessel/issues.", url))?.tag_name;
+    let release = &releases.first().ok_or_else(|| anyhow::anyhow!("Unable to find any vessel-package-set releases from {}.\nPlease try again in a few minutes or open an issue at https://github.com/dfinity/vessel/issues.", url))?.tag_name;
     fetch_package_set_impl(&client, release)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,8 +418,9 @@ type Hash = String;
 /// Dhall hash. This way it can be used to initialize the package-set file.
 pub fn fetch_latest_package_set() -> Result<(Url, Hash)> {
     let client = reqwest::blocking::Client::new();
+    let url = "https://api.github.com/repos/dfinity/vessel-package-set/releases";
     let response = client
-        .get("https://api.github.com/repos/dfinity/vessel-package-set/releases")
+        .get(url)
         .header(reqwest::header::ACCEPT, "application/vnd.github.v3+json")
         .header(reqwest::header::USER_AGENT, "vessel")
         .send()?;
@@ -430,7 +431,7 @@ pub fn fetch_latest_package_set() -> Result<(Url, Hash)> {
         ));
     }
     let releases: Vec<GhRelease> = response.json()?;
-    let release = &releases[0].tag_name;
+    let release = &releases.get(0).ok_or_else(|| anyhow::anyhow!("Unable to find any vessel-package-set releases from {}.\nPlease try again in a few minutes or open an issue at https://github.com/dfinity/vessel/issues.", url))?.tag_name;
     fetch_package_set_impl(&client, release)
 }
 


### PR DESCRIPTION
Provides a much clearer error message for the GitHub API corner case encountered in #40.