### PR TITLE
Nix: Pass system and nixpkgs to gitSource

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { system ? builtins.currentSystem, nixpkgs ? import ./nix { inherit system; } }:
 with nixpkgs;
 let
-  subpath = import ./nix/gitSource.nix;
+  subpath = import ./nix/gitSource.nix { inherit system nixpkgs; } ;
   noNixFile = name: type:
     let baseName = builtins.baseNameOf (builtins.toString name);
     in !(lib.hasSuffix ".nix" name);

--- a/nix/gitSource.nix
+++ b/nix/gitSource.nix
@@ -56,7 +56,7 @@ in
 
 # unfortunately this is not completely self-contained,
 # we needs pkgs this to get git and lib.cleanSourceWith
-let nixpkgs = import ./. {}; in
+{ system ? builtins.currentSystem, nixpkgs ? import ./. { inherit system; } }:
 
 if !isHydra && builtins.pathExists ../.git
 then


### PR DESCRIPTION
Otherwise it is not (easily) possible to import this nix setup from a nix flake, which requires pure evaluation and thus no access to `currentSystem`.